### PR TITLE
修正bilibili_video_id_from_url导致的StopIteration异常

### DIFF
--- a/nonebot_plugin_bilibili_viode/utils.py
+++ b/nonebot_plugin_bilibili_viode/utils.py
@@ -34,8 +34,8 @@ async def bilibili_video_id_from_url(uri: str) -> str:
         r"http(s)?:\/\/?(www\.)?(bilibili\.com|b23\.tv)\/(video\/)?(av[0-9]*|BV[A-Za-z0-9]*|[A-Za-z0-9]*)"
     )
     matches = pattern.finditer(uri)
-    if matches:
-        urlMatch = matches.__next__()
+    for match in matches:
+        urlMatch = match
         if urlMatch.group(3) == "b23.tv":
             async with AsyncClient() as client:
                 resp = await client.get(urlMatch.group())
@@ -43,6 +43,7 @@ async def bilibili_video_id_from_url(uri: str) -> str:
                     return await bilibili_video_id_from_url(resp.headers["Location"])
         return urlMatch.group(5)
     return None
+
 
 
 def bilibili_video_id_validate(video_id: str) -> str:


### PR DESCRIPTION
修改了函数“bilibili_video_id_from_url”
- 将urlMatch = matches.__next__()方式修改为for match in matches进行遍历

原因：在新版本Python（3.10以上，方法StopIteration停止迭代已经不可用，所以使用for语句遍历并结束迭代）

本人Python版本：3.11.2
本人使用nb-cli版本：1.2.5
本人使用的插件版本：1.0.1

但我不清楚为什么修改之后对正确的BiliBili链接也不响应了（（（